### PR TITLE
Compatibilidade com a opção de frete grátis

### DIFF
--- a/app/code/community/Frete/Click/Model/Abstract.php
+++ b/app/code/community/Frete/Click/Model/Abstract.php
@@ -15,6 +15,11 @@ abstract class Frete_Click_Model_Abstract extends Mage_Shipping_Model_Carrier_Ab
      * @var int
      */
     protected $_crossdocking = null;
+
+    /**
+     * @var boolean
+     */
+    protected $_isFreeRequest;
     
     /**
      * @return Mage_Checkout_Model_Session|Mage_Adminhtml_Model_Session_Quote
@@ -119,6 +124,18 @@ abstract class Frete_Click_Model_Abstract extends Mage_Shipping_Model_Carrier_Ab
         $weightFactor = (float)$this->getConfigData('weight_factor');
 
         foreach ($this->getItems() as $item) {
+            $totalQty = is_numeric($item->getTotalQty()) ? $item->getTotalQty() : $item->getQty();
+
+            if ($this->_isFreeRequest && ($freeQty = $item->getFreeShipping())) {
+                Mage::log(__('Free Item: %s (qty: %s | freeQty: %s)', $item->getName(), $totalQty, $freeQty));
+
+                if (!is_numeric($freeQty) || $totalQty <= $freeQty) {
+                    continue;
+                }
+                
+                $totalQty -= $freeQty;
+            }
+
             if ($_product = $item->getProduct()) {
                 $_product->load($_product->getId());
                 $height = $this->_getProductAttribute($_product, $this->getConfigData('attribute_height'));
@@ -129,7 +146,7 @@ abstract class Frete_Click_Model_Abstract extends Mage_Shipping_Model_Carrier_Ab
                 $depth *= $sizeFactor;
                 $weigth = $item->getWeight() * $weightFactor;
                 $package[] = array(
-                    'qtd'       => $item->getTotalQty(),
+                    'qtd'       => $totalQty,
                     'weight'    => Mage::helper('freteclick')->formatAmount($weigth, 2, ',', ''),
                     'height'    => Mage::helper('freteclick')->formatAmount($height, 2, ',', ''),
                     'width'     => Mage::helper('freteclick')->formatAmount($width, 2, ',', ''),

--- a/app/code/community/Frete/Click/Model/Abstract.php
+++ b/app/code/community/Frete/Click/Model/Abstract.php
@@ -126,7 +126,7 @@ abstract class Frete_Click_Model_Abstract extends Mage_Shipping_Model_Carrier_Ab
         foreach ($this->getItems() as $item) {
             $totalQty = is_numeric($item->getTotalQty()) ? $item->getTotalQty() : $item->getQty();
 
-            if ($this->_isFreeRequest && ($freeQty = $item->getFreeShipping())) {
+            if ($this->_isFreeRequest && ($freeQty = (int)$item->getFreeShipping())) {
                 Mage::log(__('Free Item: %s (qty: %s | freeQty: %s)', $item->getName(), $totalQty, $freeQty));
 
                 if (!is_numeric($freeQty) || $totalQty <= $freeQty) {

--- a/app/code/community/Frete/Click/Model/Carrier.php
+++ b/app/code/community/Frete/Click/Model/Carrier.php
@@ -7,6 +7,16 @@ class Frete_Click_Model_Carrier extends Frete_Click_Model_Abstract
     protected $_allowedMethods = array();
     
     /**
+     * @var Mage_Shipping_Model_Rate_Result
+     */
+    protected $_result;
+
+    /**
+     * @var Mage_Shipping_Model_Rate_Request
+     */
+    protected $_rawRequest;
+
+    /**
      * (non-PHPdoc)
      * @see Mage_Shipping_Model_Carrier_Interface::getAllowedMethods()
      */
@@ -44,8 +54,116 @@ class Frete_Click_Model_Carrier extends Frete_Click_Model_Abstract
     public function collectRates(Mage_Shipping_Model_Rate_Request $request)
     {
         Mage::log('Frete_Click_Model_Carrier::collectRates');
+        $this->_rawRequest = $request;
+        $this->_result = $this->_getQuotes();
+        $this->_updateFreeMethodQuote($request);
+
+        return $this->_result;
+    }
+
+    protected function _setFreeMethodRequest($freeMethod)
+    {
+        $this->_isFreeRequest = true;
+    }
+
+    /**
+     * (non-PHPdoc)
+     * @see Mage_Shipping_Model_Carrier_Abstract::getMethodPrice()
+     */
+    public function getMethodPrice($cost, $method = '')
+    {
+        $config = $this->getConfigData($this->_freeMethod);
+        $freeMethods = explode(',', $config);
+
+        return in_array($method, $freeMethods)
+            && $this->getConfigFlag('free_shipping_enable')
+            && $this->getConfigData('free_shipping_subtotal') <= $this->_rawRequest->getBaseSubtotalInclTax()
+            ? '0.00'
+            : $this->getFinalPriceWithHandlingFee($cost);
+    }
+
+    /**
+     * (non-PHPdoc)
+     * @see Mage_Shipping_Model_Carrier_Abstract::_updateFreeMethodQuote()
+     */
+    protected function _updateFreeMethodQuote($request)
+    {
+        if ($request->getFreeMethodWeight() == $request->getPackageWeight() || !$request->hasFreeMethodWeight()) {
+            return;
+        }
+
+        $freeMethods = $this->getConfigData($this->_freeMethod);
+        if (!$freeMethods) {
+            return;
+        }
+        $freeRates = array();
+        $freeMethods = explode(',', $freeMethods);
+
+        if (is_object($this->_result) && !empty($freeMethods)) {
+            foreach ($this->_result->getAllRates() as $id=>$item) {
+                if (in_array($item->getMethod(), $freeMethods)) {
+                    $freeRates[$item->getMethod()] = $id;
+                }
+            }
+        }
+
+        if (empty($freeRates)) {
+            return;
+        }
+        $price = array();
+        if ($request->getFreeMethodWeight() > 0) {
+            $this->_setFreeMethodRequest($freeMethods);
+
+            $result = $this->_getQuotes();
+            if ($result && ($rates = $result->getAllRates()) && count($rates)>0) {
+                if ((count($rates) == 1)
+                    && ($rates[0] instanceof Mage_Shipping_Model_Rate_Result_Method)
+                    && ($id = $freeRates[$rates[0]->getMethod()])
+                ) {
+                    $price[$id] = $rates[0]->getPrice();
+                }
+                if (count($rates) > 1) {
+                    foreach ($rates as $rate) {
+                        if ($rate instanceof Mage_Shipping_Model_Rate_Result_Method
+                            && in_array($rate->getMethod(), $freeMethods)
+                            && ($id = $freeRates[$rate->getMethod()])
+                        ) {
+                            $price[$id] = $rate->getPrice();
+                        }
+                    }
+                }
+            }
+        } else {
+            /**
+             * if we can apply free shipping for all order we should force price
+             * to $0.00 for shipping with out sending second request to carrier
+             */
+            foreach ($freeRates as $id) {
+                $price[$id] = 0;
+            }
+        }
+
+        /**
+         * if we did not get our free shipping method in response we must use its old price
+         */
+        if (!empty($price)) {
+            foreach ($freeRates as $id) {
+                $this->_result->getRateById($id)->setPrice($price[$id]);
+            }
+        }
+    }
+
+    /**
+     * (non-PHPdoc)
+     * @see Mage_Shipping_Model_Carrier_Abstract::_getQuotes()
+     */
+    protected function _getQuotes()
+    {
+        Mage::log('Frete_Click_Model_Carrier::_getQuotes');
         $rateResult = Mage::getModel('shipping/rate_result');
-        foreach ($this->getQuotes($request) as $quote) {
+        $quotes = $this->getQuotes($this->_rawRequest);
+
+        foreach ($quotes as $quote) {
             if (empty($quote->getPrice())) {
                 Mage::log('Empty price for ' . $quote->getMethod());
                 continue;
@@ -54,9 +172,9 @@ class Frete_Click_Model_Carrier extends Frete_Click_Model_Abstract
                 $method = Mage::getModel('shipping/rate_result_method');
                 $method->setCarrier($this->getCarrierCode());
                 $method->setCarrierTitle($this->getConfigData('title'));
-                $method->setMethod($this->getCarrierCode().'_'.$quote->getMethod());
+                $method->setMethod($quote->getMethod());
                 $method->setMethodTitle($this->getMethodTitle($quote));
-                $method->setPrice($this->getFinalPriceWithHandlingFee($quote->getPrice()));
+                $method->setPrice($this->getMethodPrice($quote->getPrice(), $quote->getMethod()));
                 $method->setCost($quote->getPrice());
             } else {
                 Mage::logException(Mage::exception('Mage_Core', $quote->getError()));

--- a/app/code/community/Frete/Click/Model/Client.php
+++ b/app/code/community/Frete/Click/Model/Client.php
@@ -7,9 +7,10 @@ class Frete_Click_Model_Client extends Varien_Http_Client
         
         if (!empty($obj->response) && !empty($obj->response->data) && !empty($obj->response->data->quote)) {
             foreach ($obj->response->data->quote as $quote) {
+                $fixMethodCode = Zend_Filter::filterStatic($quote->{'carrier-alias'}, 'Alnum');
                 $collection[] = array(
                     'quote_id'      => $quote->{'order-id'},
-                    'method'        => $quote->{'quote-id'},
+                    'method'        => $fixMethodCode,
                     'carrier_alias' => $quote->{'carrier-alias'},
                     'price'         => $quote->total,
                     'deadline'      => $quote->deadline,

--- a/app/code/community/Frete/Click/etc/system.xml
+++ b/app/code/community/Frete/Click/etc/system.xml
@@ -243,16 +243,6 @@
                             <show_in_store>0</show_in_store>
                             <depends><active>1</active></depends>
                         </showmethod>
-                        <free_method translate="label comment">
-                            <label>Free Method</label>
-                            <frontend_type>text</frontend_type>
-                            <sort_order>304</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>0</show_in_store>
-                            <depends><active>1</active></depends>
-                            <comment>Specify the methods available for free shipping. Required for Cart Rules with free shipping. Important: Alphanumeric only; separated by commas; without spaces.</comment>
-                        </free_method>
                         <free_shipping_enable translate="label">
                             <label>Free Shipping with Minimum Order Amount</label>
                             <frontend_type>select</frontend_type>

--- a/app/code/community/Frete/Click/etc/system.xml
+++ b/app/code/community/Frete/Click/etc/system.xml
@@ -243,6 +243,39 @@
                             <show_in_store>0</show_in_store>
                             <depends><active>1</active></depends>
                         </showmethod>
+                        <free_method translate="label comment">
+                            <label>Free Method</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>304</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
+                            <comment>Specify the methods available for free shipping. Required for Cart Rules with free shipping. Important: Alphanumeric only; separated by commas; without spaces.</comment>
+                        </free_method>
+                        <free_shipping_enable translate="label">
+                            <label>Free Shipping with Minimum Order Amount</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
+                            <sort_order>305</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                            <depends><active>1</active></depends>
+                        </free_shipping_enable>
+                        <free_shipping_subtotal translate="label">
+                            <label>Minimum Order Amount for Free Shipping</label>
+                            <frontend_type>text</frontend_type>
+                            <validate>validate-number validate-zero-or-greater</validate>
+                            <sort_order>306</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                            <depends>
+                                <active>1</active>
+                                <free_shipping_enable>1</free_shipping_enable>
+                            </depends>
+                        </free_shipping_subtotal>
                         <specificerrmsg translate="label">
                             <label>Displayed Error Message</label>
                             <frontend_type>textarea</frontend_type>

--- a/app/locale/pt_BR/Frete_Click.csv
+++ b/app/locale/pt_BR/Frete_Click.csv
@@ -9,4 +9,3 @@
 "Summarizes the shipping quote to two results only. The cheapest and the fastest.","Resume a cotação de frete a apenas dois resultados. O frete mais econômico, e o frete mais rápido."
 "Zip From","CEP inicial"
 "Zip To","CEP final"
-"Specify the methods available for free shipping. Required for Cart Rules with free shipping. Important: Alphanumeric only; separated by commas; without spaces.","Especifique os métodos de entrega para frete grátis. Obrigatório caso utilize opção de frete grátis nas Regras de Carrinho. Importante: Somente caracteres alphanuméricos; separado por vírgulas; sem espaços."

--- a/app/locale/pt_BR/Frete_Click.csv
+++ b/app/locale/pt_BR/Frete_Click.csv
@@ -9,3 +9,4 @@
 "Summarizes the shipping quote to two results only. The cheapest and the fastest.","Resume a cotação de frete a apenas dois resultados. O frete mais econômico, e o frete mais rápido."
 "Zip From","CEP inicial"
 "Zip To","CEP final"
+"Specify the methods available for free shipping. Required for Cart Rules with free shipping. Important: Alphanumeric only; separated by commas; without spaces.","Especifique os métodos de entrega para frete grátis. Obrigatório caso utilize opção de frete grátis nas Regras de Carrinho. Importante: Somente caracteres alphanuméricos; separado por vírgulas; sem espaços."


### PR DESCRIPTION
Foi desenvolvida compatibilidade com a opção de frete grátis, nas Regras de Carrinho do Magento.

* Essa alteração permite aderir as regras de frete grátis.
* Não é possível escolher quais métodos (transportadoras) serão utilizadas para frete grátis.